### PR TITLE
task edit inputs now show up in the correct place

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -54,16 +54,16 @@
     {
       "id": 3,
       "userId": "4",
-      "task": "Bring Melba and Cormac to Vet",
+      "task": "Bring Cormac to Vet",
       "expectedComplete": "2020-02-19T09:30",
       "isComplete": false
     },
     {
-      "task": "Oil Change",
+      "id": 4,
+      "userId": "4",
+      "task": "Oil Change and tire alignment",
       "expectedComplete": "2020-02-21T14:00",
-      "isComplete": false,
-      "userId": 4,
-      "id": 4
+      "isComplete": false
     }
   ],
   "events": [

--- a/src/scripts/tasks/HTMLfactory.js
+++ b/src/scripts/tasks/HTMLfactory.js
@@ -3,7 +3,7 @@ const HTMLFactories = {
     return `<div class="task" id="task--${task.id}">
     <div id="taskNameDiv">
     <h4 id="taskName--${task.id}">${task.task}</h2>
-    <div id="taskEditBar"></div>
+    <div id="taskEditBar--${task.id}"></div>
     <input id="completeTask--${task.id}" type="checkbox">
     </div>
     <h6 id="expectedComplete--${task.id}">${task.expectedComplete}</h5>
@@ -43,8 +43,8 @@ const HTMLFactories = {
     </div>
     </div>`;
   },
-  makeEditTaskNameForm() {
-    const taskEditBar = document.getElementById("taskEditBar");
+  makeEditTaskNameForm(taskId) {
+    const taskEditBar = document.getElementById(`taskEditBar--${taskId}`);
     taskEditBar.innerHTML = `
       <div>
       <input type="hidden" id="editTaskId" value="">

--- a/src/scripts/tasks/eventListeners.js
+++ b/src/scripts/tasks/eventListeners.js
@@ -49,8 +49,8 @@ const events = {
     const tasks = document.querySelector("#tasks");
     tasks.addEventListener("click", event => {
       if (event.target.id.startsWith("taskName--")) {
-        HTMLFactories.makeEditTaskNameForm();
         const taskToEdit = event.target.id.split("--")[1];
+        HTMLFactories.makeEditTaskNameForm(taskToEdit);
         const hiddenId = document.querySelector("#editTaskId");
         const userId = document.querySelector("#editTaskUserId");
         const taskName = document.querySelector("#editTaskName");


### PR DESCRIPTION
1. git fetch --all
2. git checkout JP--tasksRedux

Please verify that:
-when you click task names, an input bar shows up below the task you clicked
-when you press enter, the change to the name is saved and rendered to the DOM